### PR TITLE
fix a potential dead lock 

### DIFF
--- a/src/main/java/br/com/leonardoz/patterns/task_convergence/TaskConvergence.java
+++ b/src/main/java/br/com/leonardoz/patterns/task_convergence/TaskConvergence.java
@@ -60,7 +60,7 @@ public class TaskConvergence {
 	public TaskConvergence() {
 		barrier = new CyclicBarrier(CORES, onComplete);
 		synchronizedLinkedList = Collections.synchronizedList(new LinkedList<>());
-		executor = Executors.newFixedThreadPool(4);
+		executor = Executors.newFixedThreadPool(CORES);
 	}
 
 	public void run() {


### PR DESCRIPTION
TaskConvergence when then number of core processor is greater than 4, main thread will be blocked