### PR TITLE
ResourcePool get release semaphore only on exception

### DIFF
--- a/src/main/java/br/com/leonardoz/patterns/resource_pool/ResourcePool.java
+++ b/src/main/java/br/com/leonardoz/patterns/resource_pool/ResourcePool.java
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeUnit;
 public class ResourcePool<T> {
 
 	private final static TimeUnit TIME_UNIT = TimeUnit.SECONDS;
-	private Semaphore semaphore;
-	private BlockingQueue<T> resources;
+	private final Semaphore semaphore;
+	private final BlockingQueue<T> resources;
 
 	public ResourcePool(int poolSize, List<T> initializedResources) {
 		this.semaphore = new Semaphore(poolSize, true);
@@ -39,9 +39,13 @@ public class ResourcePool<T> {
 		semaphore.acquire();
 		try {
 			T resource = resources.poll(secondsToTimeout, TIME_UNIT);
+			if (resource == null) {
+				semaphore.release();
+			}
 			return resource;
-		} finally {
+		} catch (Exception e) {
 			semaphore.release();
+			throw e;
 		}
 	}
 


### PR DESCRIPTION
The timed get in ResourcePool is releasing semaphore in a finally block which means it will be released even if resource was acquired successfully. Isn't the semaphore supposed to track the number of resources available in the pool?

The semaphore should only be released if a resource could not be acquired in the given time (i.e. returns null) or throws some exception. Otherwise it should not be released.